### PR TITLE
Add Vendor PDF Catalog Importer plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # VC-WooCatalog
-Upload Catalogs in PDF convert them go jpg, scan them, create products
+
+This repository contains the **Vendor PDF Catalog Importer** plugin. Vendors can upload product catalogs in PDF format and automatically generate WooCommerce products for each page.
+
+## Development
+
+The plugin source is located in the `vendor-pdf-catalog-importer` directory.

--- a/vendor-pdf-catalog-importer/includes/AdminPage.php
+++ b/vendor-pdf-catalog-importer/includes/AdminPage.php
@@ -1,0 +1,75 @@
+<?php
+namespace VendorPDFCatalogImporter\Includes;
+
+/**
+ * Admin page to upload PDFs.
+ */
+class AdminPage {
+    /**
+     * Init hooks.
+     */
+    public static function init() {
+        add_action( 'admin_menu', [ __CLASS__, 'menu' ] );
+        add_action( 'admin_post_vpci_upload', [ __CLASS__, 'handle_upload' ] );
+    }
+
+    /**
+     * Register menu page for vendors.
+     */
+    public static function menu() {
+        if ( ! current_user_can( 'read' ) ) {
+            return;
+        }
+        add_menu_page( __( 'PDF Catalog Import', 'vendor-pdf-catalog-importer' ), __( 'PDF Catalog Import', 'vendor-pdf-catalog-importer' ), 'read', 'vpci-import', [ __CLASS__, 'page' ] );
+    }
+
+    /**
+     * Render upload form.
+     */
+    public static function page() {
+        if ( ! current_user_can( 'read' ) ) {
+            return;
+        }
+        ?>
+        <div class="wrap">
+            <h1><?php _e( 'Upload PDF Catalog', 'vendor-pdf-catalog-importer' ); ?></h1>
+            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data">
+                <?php wp_nonce_field( 'vpci_upload' ); ?>
+                <input type="hidden" name="action" value="vpci_upload" />
+                <input type="file" name="vpci_pdf" accept="application/pdf" required />
+                <?php submit_button( __( 'Upload', 'vendor-pdf-catalog-importer' ) ); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * Handle PDF upload from admin page.
+     */
+    public static function handle_upload() {
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Access denied', 'vendor-pdf-catalog-importer' ) );
+        }
+        check_admin_referer( 'vpci_upload' );
+
+        if ( empty( $_FILES['vpci_pdf']['name'] ) ) {
+            wp_safe_redirect( wp_get_referer() );
+            exit;
+        }
+
+        $file = $_FILES['vpci_pdf'];
+        if ( 'application/pdf' !== $file['type'] || $file['size'] > 10 * 1024 * 1024 ) {
+            wp_die( __( 'Invalid file', 'vendor-pdf-catalog-importer' ) );
+        }
+
+        $upload = wp_handle_upload( $file, [ 'test_form' => false ] );
+        if ( isset( $upload['file'] ) ) {
+            $vendor_id = get_current_user_id();
+            $job_id = JobManager::create_job( $vendor_id, $upload['file'] );
+            PDFProcessor::schedule_job( $job_id );
+        }
+
+        wp_safe_redirect( admin_url( 'admin.php?page=vpci-import' ) );
+        exit;
+    }
+}

--- a/vendor-pdf-catalog-importer/includes/Autoloader.php
+++ b/vendor-pdf-catalog-importer/includes/Autoloader.php
@@ -1,0 +1,30 @@
+<?php
+namespace VendorPDFCatalogImporter\Includes;
+
+/**
+ * Simple PSR-4 autoloader.
+ */
+class Autoloader {
+    /**
+     * Register autoloader for plugin classes.
+     */
+    public static function register() {
+        spl_autoload_register( [ __CLASS__, 'autoload' ] );
+    }
+
+    /**
+     * Autoload callback.
+     */
+    public static function autoload( $class ) {
+        if ( 0 !== strpos( $class, 'VendorPDFCatalogImporter\\' ) ) {
+            return;
+        }
+
+        $class   = str_replace( 'VendorPDFCatalogImporter\\', '', $class );
+        $path    = plugin_dir_path( dirname( __DIR__ ) ) . 'includes/' . str_replace( '\\', '/', $class ) . '.php';
+
+        if ( file_exists( $path ) ) {
+            require_once $path;
+        }
+    }
+}

--- a/vendor-pdf-catalog-importer/includes/FrontendShortcode.php
+++ b/vendor-pdf-catalog-importer/includes/FrontendShortcode.php
@@ -1,0 +1,49 @@
+<?php
+namespace VendorPDFCatalogImporter\Includes;
+
+/**
+ * Shortcode for vendor upload form.
+ */
+class FrontendShortcode {
+    public static function init() {
+        add_shortcode( 'vendor_pdf_catalog_form', [ __CLASS__, 'render_form' ] );
+        add_action( 'admin_post_nopriv_vpci_upload_front', [ __CLASS__, 'handle_upload' ] );
+        add_action( 'admin_post_vpci_upload_front', [ __CLASS__, 'handle_upload' ] );
+    }
+
+    public static function render_form() {
+        if ( ! is_user_logged_in() ) {
+            return __( 'Please log in to upload catalog.', 'vendor-pdf-catalog-importer' );
+        }
+        ob_start();
+        ?>
+        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data">
+            <?php wp_nonce_field( 'vpci_upload_front' ); ?>
+            <input type="hidden" name="action" value="vpci_upload_front" />
+            <input type="file" name="vpci_pdf" accept="application/pdf" required />
+            <button type="submit"><?php _e( 'Upload', 'vendor-pdf-catalog-importer' ); ?></button>
+        </form>
+        <?php
+        return ob_get_clean();
+    }
+
+    public static function handle_upload() {
+        if ( ! is_user_logged_in() ) {
+            wp_die( __( 'Access denied', 'vendor-pdf-catalog-importer' ) );
+        }
+        check_admin_referer( 'vpci_upload_front' );
+
+        $file = $_FILES['vpci_pdf'];
+        if ( empty( $file['name'] ) || 'application/pdf' !== $file['type'] || $file['size'] > 10 * 1024 * 1024 ) {
+            wp_die( __( 'Invalid file', 'vendor-pdf-catalog-importer' ) );
+        }
+        $upload = wp_handle_upload( $file, [ 'test_form' => false ] );
+        if ( isset( $upload['file'] ) ) {
+            $vendor_id = get_current_user_id();
+            $job_id = JobManager::create_job( $vendor_id, $upload['file'] );
+            PDFProcessor::schedule_job( $job_id );
+        }
+        wp_safe_redirect( wp_get_referer() );
+        exit;
+    }
+}

--- a/vendor-pdf-catalog-importer/includes/JobManager.php
+++ b/vendor-pdf-catalog-importer/includes/JobManager.php
@@ -1,0 +1,51 @@
+<?php
+namespace VendorPDFCatalogImporter\Includes;
+
+use WP_Error;
+
+/**
+ * Manage import jobs.
+ */
+class JobManager {
+    public static function init() {
+        // Nothing for now.
+    }
+
+    /**
+     * Create a job record.
+     */
+    public static function create_job( $vendor_id, $pdf_path ) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'vendor_pdf_jobs';
+        $wpdb->insert( $table, [
+            'vendor_id' => $vendor_id,
+            'pdf_path'  => $pdf_path,
+            'status'    => 'pending',
+            'created_at' => current_time( 'mysql' ),
+            'updated_at' => current_time( 'mysql' ),
+        ] );
+        return $wpdb->insert_id;
+    }
+
+    /**
+     * Update job status.
+     */
+    public static function update_status( $job_id, $status ) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'vendor_pdf_jobs';
+        $wpdb->update( $table, [
+            'status'     => $status,
+            'updated_at' => current_time( 'mysql' ),
+        ], [ 'id' => $job_id ] );
+    }
+
+    /**
+     * Get jobs by vendor.
+     */
+    public static function get_jobs( $vendor_id, $paged = 1, $per_page = 20 ) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'vendor_pdf_jobs';
+        $offset = ( $paged - 1 ) * $per_page;
+        return $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $table WHERE vendor_id = %d ORDER BY id DESC LIMIT %d OFFSET %d", $vendor_id, $per_page, $offset ) );
+    }
+}

--- a/vendor-pdf-catalog-importer/includes/Logger.php
+++ b/vendor-pdf-catalog-importer/includes/Logger.php
@@ -1,0 +1,13 @@
+<?php
+namespace VendorPDFCatalogImporter\Includes;
+
+/**
+ * Simple logger to file.
+ */
+class Logger {
+    public static function log( $message ) {
+        $upload_dir = wp_upload_dir();
+        $file = trailingslashit( $upload_dir['basedir'] ) . 'vpci.log';
+        error_log( '[' . current_time( 'mysql' ) . '] ' . $message . "\n", 3, $file );
+    }
+}

--- a/vendor-pdf-catalog-importer/includes/PDFProcessor.php
+++ b/vendor-pdf-catalog-importer/includes/PDFProcessor.php
@@ -1,0 +1,76 @@
+<?php
+namespace VendorPDFCatalogImporter\Includes;
+
+use Imagick;
+use WP_Error;
+
+/**
+ * Convert PDF and create products.
+ */
+class PDFProcessor {
+    public static function init() {
+        add_action( 'vpci_process_job', [ __CLASS__, 'process_job' ] );
+    }
+
+    /**
+     * Schedule async job using Action Scheduler if available.
+     */
+    public static function schedule_job( $job_id ) {
+        if ( class_exists( 'ActionScheduler' ) ) {
+            as_enqueue_async_action( 'vpci_process_job', [ 'job_id' => $job_id ], 'vpci' );
+        } else {
+            wp_schedule_single_event( time() + 60, 'vpci_process_job', [ 'job_id' => $job_id ] );
+        }
+    }
+
+    /**
+     * Process job: convert PDF, parse text, create products.
+     */
+    public static function process_job( $args ) {
+        $job_id = $args['job_id'];
+        JobManager::update_status( $job_id, 'processing' );
+        global $wpdb;
+        $table = $wpdb->prefix . 'vendor_pdf_jobs';
+        $job   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $table WHERE id = %d", $job_id ) );
+        if ( ! $job ) {
+            return;
+        }
+        $upload_dir = wp_upload_dir();
+        $dest_dir = trailingslashit( $upload_dir['basedir'] ) . 'vendor-catalogs/' . $job->vendor_id . '/' . $job_id . '/';
+        wp_mkdir_p( $dest_dir );
+        try {
+            $imagick = new Imagick();
+            $imagick->setResolution( 150, 150 );
+            $imagick->readImage( $job->pdf_path );
+            foreach ( $imagick as $i => $page ) {
+                $page->setImageFormat( 'jpeg' );
+                $page->setImageCompressionQuality( 85 );
+                $page->scaleImage( 1280, 0 );
+                $filename = $dest_dir . ( $i + 1 ) . '.jpg';
+                $page->writeImage( $filename );
+                $text = self::extract_text( $job->pdf_path, $i );
+                ProductCreator::create_from_page( $job->vendor_id, $filename, $text );
+            }
+            JobManager::update_status( $job_id, 'completed' );
+        } catch ( \Exception $e ) {
+            JobManager::update_status( $job_id, 'error' );
+            Logger::log( 'Job ' . $job_id . ' failed: ' . $e->getMessage() );
+        }
+    }
+
+    /**
+     * Extract text from PDF page.
+     */
+    protected static function extract_text( $pdf, $page = 0 ) {
+        if ( class_exists( '\Smalot\PdfParser\Parser' ) ) {
+            $parser = new \Smalot\PdfParser\Parser();
+            $pdf = $parser->parseFile( $pdf );
+            $pages = $pdf->getPages();
+            if ( isset( $pages[ $page ] ) ) {
+                return $pages[ $page ]->getText();
+            }
+        }
+        // Fallback empty text.
+        return '';
+    }
+}

--- a/vendor-pdf-catalog-importer/includes/Plugin.php
+++ b/vendor-pdf-catalog-importer/includes/Plugin.php
@@ -1,0 +1,50 @@
+<?php
+namespace VendorPDFCatalogImporter\Includes;
+
+use VendorPDFCatalogImporter\Includes\AdminPage;
+use VendorPDFCatalogImporter\Includes\FrontendShortcode;
+use VendorPDFCatalogImporter\Includes\JobManager;
+use VendorPDFCatalogImporter\Includes\PDFProcessor;
+
+/**
+ * Main plugin bootstrap.
+ */
+class Plugin {
+    /**
+     * Initialize plugin hooks.
+     */
+    public static function init() {
+        register_activation_hook( VPCI_PATH . 'vendor-pdf-catalog-importer.php', [ __CLASS__, 'activate' ] );
+        add_action( 'plugins_loaded', [ __CLASS__, 'load' ] );
+    }
+
+    /**
+     * Activation hook to create tables.
+     */
+    public static function activate() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'vendor_pdf_jobs';
+        $charset_collate = $wpdb->get_charset_collate();
+        $sql = "CREATE TABLE IF NOT EXISTS $table (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            vendor_id bigint(20) unsigned NOT NULL,
+            pdf_path text NOT NULL,
+            status varchar(20) NOT NULL DEFAULT 'pending',
+            created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id)
+        ) $charset_collate;";
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta( $sql );
+    }
+
+    /**
+     * Load plugin components.
+     */
+    public static function load() {
+        AdminPage::init();
+        FrontendShortcode::init();
+        JobManager::init();
+        PDFProcessor::init();
+    }
+}

--- a/vendor-pdf-catalog-importer/includes/ProductCreator.php
+++ b/vendor-pdf-catalog-importer/includes/ProductCreator.php
@@ -1,0 +1,75 @@
+<?php
+namespace VendorPDFCatalogImporter\Includes;
+
+use WC_Product_Simple;
+use WC_Product_Variable;
+use WC_Product_Attribute;
+use WC_Product_Variation;
+
+/**
+ * Create products from images and text.
+ */
+class ProductCreator {
+    /**
+     * Create product from page image and text.
+     */
+    public static function create_from_page( $vendor_id, $image, $text ) {
+        $title = self::parse_field( 'title', $text );
+        $sku   = self::parse_field( 'sku', $text );
+        $short = self::parse_field( 'short', $text );
+        $long  = self::parse_field( 'long', $text );
+
+        $product = new WC_Product_Simple();
+        $product->set_name( $title ? $title : __( 'Imported Product', 'vendor-pdf-catalog-importer' ) );
+        if ( $sku ) {
+            $product->set_sku( $sku );
+        }
+        $product->set_description( $long );
+        $product->set_short_description( $short );
+        $product->set_catalog_visibility( 'visible' );
+        $product->set_status( 'draft' );
+        $product->set_reviews_allowed( true );
+        $product->set_menu_order( 0 );
+        $product->set_manage_stock( false );
+        $product_id = $product->save();
+
+        // Attach image as featured image.
+        $attachment_id = self::attach_image( $product_id, $image );
+        if ( $attachment_id ) {
+            set_post_thumbnail( $product_id, $attachment_id );
+        }
+
+        // Assign author (vendor).
+        wp_update_post( [ 'ID' => $product_id, 'post_author' => $vendor_id ] );
+    }
+
+    /**
+     * Parse text to get field placeholder (very basic parsing for demo).
+     */
+    protected static function parse_field( $field, $text ) {
+        $pattern = '/' . $field . ':\s*(.+)/i';
+        if ( preg_match( $pattern, $text, $m ) ) {
+            return sanitize_text_field( $m[1] );
+        }
+        return '';
+    }
+
+    /**
+     * Attach image to product.
+     */
+    protected static function attach_image( $post_id, $file ) {
+        $upload_dir = wp_upload_dir();
+        $relative   = str_replace( trailingslashit( $upload_dir['basedir'] ), '', $file );
+        $attachment = [
+            'post_mime_type' => 'image/jpeg',
+            'post_title'     => get_the_title( $post_id ),
+            'post_content'   => '',
+            'post_status'    => 'inherit'
+        ];
+        $attach_id = wp_insert_attachment( $attachment, $relative, $post_id );
+        require_once ABSPATH . 'wp-admin/includes/image.php';
+        $attach_data = wp_generate_attachment_metadata( $attach_id, $file );
+        wp_update_attachment_metadata( $attach_id, $attach_data );
+        return $attach_id;
+    }
+}

--- a/vendor-pdf-catalog-importer/readme.txt
+++ b/vendor-pdf-catalog-importer/readme.txt
@@ -1,0 +1,23 @@
+=== Vendor PDF Catalog Importer ===
+Contributors: codex
+Requires at least: 5.8
+Tested up to: 6.5
+Requires PHP: 7.4
+Tags: woocommerce, multivendor, pdf
+Stable tag: 1.0.0
+License: GPLv2 or later
+
+== Description ==
+
+Allow vendors to upload a PDF catalog and automatically create WooCommerce products. Each page of the PDF is converted to an image and parsed for product information.
+
+== Installation ==
+
+1. Upload the plugin folder to `/wp-content/plugins/`.
+2. Activate the plugin through the Plugins menu in WordPress.
+3. Vendors can upload PDFs from **PDF Catalog Import** menu or using `[vendor_pdf_catalog_form]` shortcode.
+
+== Changelog ==
+
+= 1.0.0 =
+* Initial release.

--- a/vendor-pdf-catalog-importer/vendor-pdf-catalog-importer.php
+++ b/vendor-pdf-catalog-importer/vendor-pdf-catalog-importer.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Plugin Name: Vendor PDF Catalog Importer
+ * Description: Upload PDF catalogs to create WooCommerce products automatically.
+ * Version: 1.0.0
+ * Author: Codex
+ * License: GPL2
+ * Text Domain: vendor-pdf-catalog-importer
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'VPCI_PATH', plugin_dir_path( __FILE__ ) );
+
+define( 'VPCI_URL', plugin_dir_url( __FILE__ ) );
+
+require_once VPCI_PATH . 'includes/Autoloader.php';
+VendorPDFCatalogImporter\Includes\Autoloader::register();
+
+// Run the plugin.
+VendorPDFCatalogImporter\Includes\Plugin::init();


### PR DESCRIPTION
## Summary
- add skeleton plugin `Vendor PDF Catalog Importer`
- implement PDF upload pages and shortcode
- process PDFs asynchronously and generate products
- add readme with installation notes
- update repo README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686587bce27c832eb3731ed4b8d58348